### PR TITLE
Minor fix to reflect change in seq_printf.

### DIFF
--- a/iptables-module/xt_mpeg2ts.c
+++ b/iptables-module/xt_mpeg2ts.c
@@ -1296,17 +1296,15 @@ static void mpeg2ts_seq_stop(struct seq_file *s, void *v)
 	kfree(bucket);
 }
 
-static int mpeg2ts_seq_show_real(struct mpeg2ts_stream *stream,
+static void mpeg2ts_seq_show_real(struct mpeg2ts_stream *stream,
 				 struct seq_file *s, unsigned int bucket)
 {
-	int res;
-
 	if (!atomic_inc_not_zero(&stream->use)) {
 		/* If "use" is zero, then we about to be free'd */
 		return 0;
 	}
 
-	res = seq_printf(s, "bucket:%d dst:%pI4 src:%pI4 dport:%u sport:%u "
+	seq_printf(s, "bucket:%d dst:%pI4 src:%pI4 dport:%u sport:%u "
 			    "pids:%d skips:%llu discontinuity:%llu "
 			    "payload_bytes:%llu packets:%llu\n",
 			 bucket,
@@ -1322,8 +1320,6 @@ static int mpeg2ts_seq_show_real(struct mpeg2ts_stream *stream,
 		);
 
 	atomic_dec(&stream->use);
-
-	return res;
 }
 
 static int mpeg2ts_seq_show(struct seq_file *s, void *v)
@@ -1384,10 +1380,7 @@ static int mpeg2ts_seq_show(struct seq_file *s, void *v)
 #endif
 						 &htable->stream_hash[*bucket],
 						 node) {
-				if (mpeg2ts_seq_show_real(stream, s, *bucket)) {
-					rcu_read_unlock();
-					return -1;
-				}
+				mpeg2ts_seq_show_real(stream, s, *bucket);
 			}
 		}
 		rcu_read_unlock();


### PR DESCRIPTION
Apparently the seq_printf function doesn't return an int anymore but is now a void function instead. This commit contains a minor update in mpeg2ts_seq_show_real() to not depend on the return value of seq_printf anymore.